### PR TITLE
[webpubsub] fix text being passed to json kwarg issue

### DIFF
--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_configuration.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_configuration.py
@@ -30,6 +30,8 @@ class WebPubSubServiceClientConfiguration(Configuration):
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure.
     :type credential: ~azure.core.credentials.TokenCredential
+    :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this default value may result in unsupported behavior.
+    :paramtype api_version: str
     """
 
     def __init__(
@@ -39,15 +41,17 @@ class WebPubSubServiceClientConfiguration(Configuration):
         **kwargs  # type: Any
     ):
         # type: (...) -> None
+        super(WebPubSubServiceClientConfiguration, self).__init__(**kwargs)
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credential is None:
             raise ValueError("Parameter 'credential' must not be None.")
-        super(WebPubSubServiceClientConfiguration, self).__init__(**kwargs)
 
         self.endpoint = endpoint
         self.credential = credential
-        self.api_version = "2021-10-01"
+        self.api_version = api_version
         self.credential_scopes = kwargs.pop('credential_scopes', ['https://webpubsub.azure.com/.default'])
         kwargs.setdefault('sdk_moniker', 'messaging-webpubsubservice/{}'.format(VERSION))
         self._configure(**kwargs)

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_web_pub_sub_service_client.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_web_pub_sub_service_client.py
@@ -29,6 +29,9 @@ class WebPubSubServiceClient(WebPubSubServiceClientOperationsMixin):
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure.
     :type credential: ~azure.core.credentials.TokenCredential
+    :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+     default value may result in unsupported behavior.
+    :paramtype api_version: str
     """
 
     def __init__(

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/aio/_configuration.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/aio/_configuration.py
@@ -28,6 +28,8 @@ class WebPubSubServiceClientConfiguration(Configuration):
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
+    :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this default value may result in unsupported behavior.
+    :paramtype api_version: str
     """
 
     def __init__(
@@ -36,15 +38,17 @@ class WebPubSubServiceClientConfiguration(Configuration):
         credential: "AsyncTokenCredential",
         **kwargs: Any
     ) -> None:
+        super(WebPubSubServiceClientConfiguration, self).__init__(**kwargs)
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credential is None:
             raise ValueError("Parameter 'credential' must not be None.")
-        super(WebPubSubServiceClientConfiguration, self).__init__(**kwargs)
 
         self.endpoint = endpoint
         self.credential = credential
-        self.api_version = "2021-10-01"
+        self.api_version = api_version
         self.credential_scopes = kwargs.pop('credential_scopes', ['https://webpubsub.azure.com/.default'])
         kwargs.setdefault('sdk_moniker', 'messaging-webpubsubservice/{}'.format(VERSION))
         self._configure(**kwargs)

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/aio/_web_pub_sub_service_client.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/aio/_web_pub_sub_service_client.py
@@ -29,6 +29,9 @@ class WebPubSubServiceClient(WebPubSubServiceClientOperationsMixin):
     :type endpoint: str
     :param credential: Credential needed for the client to connect to Azure.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
+    :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+     default value may result in unsupported behavior.
+    :paramtype api_version: str
     """
 
     def __init__(

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/aio/operations/_operations.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/aio/operations/_operations.py
@@ -19,6 +19,7 @@ from ...operations._operations import build_add_connection_to_group_request, bui
 
 T = TypeVar('T')
 ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T, Dict[str, Any]], Any]]
+JSONType = Any
 
 class WebPubSubServiceClientOperationsMixin:
 
@@ -45,6 +46,9 @@ class WebPubSubServiceClientOperationsMixin:
         :paramtype role: list[str]
         :keyword minutes_to_expire: The expire time of the generated token.
         :paramtype minutes_to_expire: int
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: JSON object
         :rtype: Any
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -63,9 +67,12 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_generate_client_token_request(
             hub=hub,
+            api_version=api_version,
             user_id=user_id,
             role=role,
             minutes_to_expire=minutes_to_expire,
@@ -116,6 +123,9 @@ class WebPubSubServiceClientOperationsMixin:
         :paramtype excluded: list[str]
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -126,9 +136,12 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_close_all_connections_request(
             hub=hub,
+            api_version=api_version,
             excluded=excluded,
             reason=reason,
             template_url=self.close_all_connections.metadata['url'],
@@ -155,7 +168,7 @@ class WebPubSubServiceClientOperationsMixin:
     async def send_to_all(
         self,
         hub: str,
-        message: Union[IO, str],
+        message: Union[IO, str, JSONType],
         *,
         excluded: Optional[List[str]] = None,
         **kwargs: Any
@@ -168,9 +181,12 @@ class WebPubSubServiceClientOperationsMixin:
          alpha-numeric characters or underscore.
         :type hub: str
         :param message: The payload body.
-        :type message: IO or str
+        :type message: IO or str or JSONType
         :keyword excluded: Excluded connection Ids.
         :paramtype excluded: list[str]
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -184,14 +200,15 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -200,6 +217,7 @@ class WebPubSubServiceClientOperationsMixin:
 
         request = build_send_to_all_request(
             hub=hub,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -240,6 +258,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type hub: str
         :param connection_id: The connection Id.
         :type connection_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -250,10 +271,13 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_connection_exists_request(
             hub=hub,
             connection_id=connection_id,
+            api_version=api_version,
             template_url=self.connection_exists.metadata['url'],
         )
         path_format_arguments = {
@@ -295,6 +319,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type connection_id: str
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -305,10 +332,13 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_close_connection_request(
             hub=hub,
             connection_id=connection_id,
+            api_version=api_version,
             reason=reason,
             template_url=self.close_connection.metadata['url'],
         )
@@ -335,7 +365,7 @@ class WebPubSubServiceClientOperationsMixin:
         self,
         hub: str,
         connection_id: str,
-        message: Union[IO, str],
+        message: Union[IO, str, JSONType],
         **kwargs: Any
     ) -> None:
         """Send content inside request body to the specific connection.
@@ -348,7 +378,10 @@ class WebPubSubServiceClientOperationsMixin:
         :param connection_id: The connection Id.
         :type connection_id: str
         :param message: The payload body.
-        :type message: IO or str
+        :type message: IO or str or JSONType
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -362,14 +395,15 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -379,6 +413,7 @@ class WebPubSubServiceClientOperationsMixin:
         request = build_send_to_connection_request(
             hub=hub,
             connection_id=connection_id,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -418,6 +453,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type hub: str
         :param group: Target group name, which length should be greater than 0 and less than 1025.
         :type group: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -428,10 +466,13 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_group_exists_request(
             hub=hub,
             group=group,
+            api_version=api_version,
             template_url=self.group_exists.metadata['url'],
         )
         path_format_arguments = {
@@ -476,6 +517,9 @@ class WebPubSubServiceClientOperationsMixin:
         :paramtype excluded: list[str]
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -486,10 +530,13 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_close_group_connections_request(
             hub=hub,
             group=group,
+            api_version=api_version,
             excluded=excluded,
             reason=reason,
             template_url=self.close_group_connections.metadata['url'],
@@ -517,7 +564,7 @@ class WebPubSubServiceClientOperationsMixin:
         self,
         hub: str,
         group: str,
-        message: Union[IO, str],
+        message: Union[IO, str, JSONType],
         *,
         excluded: Optional[List[str]] = None,
         **kwargs: Any
@@ -532,9 +579,12 @@ class WebPubSubServiceClientOperationsMixin:
         :param group: Target group name, which length should be greater than 0 and less than 1025.
         :type group: str
         :param message: The payload body.
-        :type message: IO or str
+        :type message: IO or str or JSONType
         :keyword excluded: Excluded connection Ids.
         :paramtype excluded: list[str]
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -548,14 +598,15 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -565,6 +616,7 @@ class WebPubSubServiceClientOperationsMixin:
         request = build_send_to_group_request(
             hub=hub,
             group=group,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -608,6 +660,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type group: str
         :param connection_id: Target connection Id.
         :type connection_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -618,11 +673,14 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_add_connection_to_group_request(
             hub=hub,
             group=group,
             connection_id=connection_id,
+            api_version=api_version,
             template_url=self.add_connection_to_group.metadata['url'],
         )
         path_format_arguments = {
@@ -662,6 +720,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type group: str
         :param connection_id: Target connection Id.
         :type connection_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -672,11 +733,14 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_remove_connection_from_group_request(
             hub=hub,
             group=group,
             connection_id=connection_id,
+            api_version=api_version,
             template_url=self.remove_connection_from_group.metadata['url'],
         )
         path_format_arguments = {
@@ -713,6 +777,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type hub: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -723,10 +790,13 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_user_exists_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.user_exists.metadata['url'],
         )
         path_format_arguments = {
@@ -771,6 +841,9 @@ class WebPubSubServiceClientOperationsMixin:
         :paramtype excluded: list[str]
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -781,10 +854,13 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_close_user_connections_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             excluded=excluded,
             reason=reason,
             template_url=self.close_user_connections.metadata['url'],
@@ -826,6 +902,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type user_id: str
         :param message: The payload body.
         :type message: IO or str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -839,14 +918,15 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -856,6 +936,7 @@ class WebPubSubServiceClientOperationsMixin:
         request = build_send_to_user_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -898,6 +979,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type group: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -908,11 +992,14 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_add_user_to_group_request(
             hub=hub,
             group=group,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.add_user_to_group.metadata['url'],
         )
         path_format_arguments = {
@@ -952,6 +1039,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type group: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -962,11 +1052,14 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_remove_user_from_group_request(
             hub=hub,
             group=group,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.remove_user_from_group.metadata['url'],
         )
         path_format_arguments = {
@@ -1003,6 +1096,9 @@ class WebPubSubServiceClientOperationsMixin:
         :type hub: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1013,10 +1109,13 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_remove_user_from_all_groups_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.remove_user_from_all_groups.metadata['url'],
         )
         path_format_arguments = {
@@ -1062,6 +1161,9 @@ class WebPubSubServiceClientOperationsMixin:
         :keyword target_name: The meaning of the target depends on the specific permission. For
          joinLeaveGroup and sendToGroup, targetName is a required parameter standing for the group name.
         :paramtype target_name: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1072,11 +1174,14 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_grant_permission_request(
             hub=hub,
             permission=permission,
             connection_id=connection_id,
+            api_version=api_version,
             target_name=target_name,
             template_url=self.grant_permission.metadata['url'],
         )
@@ -1123,6 +1228,9 @@ class WebPubSubServiceClientOperationsMixin:
         :keyword target_name: The meaning of the target depends on the specific permission. For
          joinLeaveGroup and sendToGroup, targetName is a required parameter standing for the group name.
         :paramtype target_name: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1133,11 +1241,14 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_revoke_permission_request(
             hub=hub,
             permission=permission,
             connection_id=connection_id,
+            api_version=api_version,
             target_name=target_name,
             template_url=self.revoke_permission.metadata['url'],
         )
@@ -1184,6 +1295,9 @@ class WebPubSubServiceClientOperationsMixin:
         :keyword target_name: The meaning of the target depends on the specific permission. For
          joinLeaveGroup and sendToGroup, targetName is a required parameter standing for the group name.
         :paramtype target_name: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1194,11 +1308,14 @@ class WebPubSubServiceClientOperationsMixin:
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_check_permission_request(
             hub=hub,
             permission=permission,
             connection_id=connection_id,
+            api_version=api_version,
             target_name=target_name,
             template_url=self.check_permission.metadata['url'],
         )

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/operations/_operations.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/operations/_operations.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     T = TypeVar('T')
     ClsType = Optional[Callable[[PipelineResponse[HttpRequest, HttpResponse], T, Dict[str, Any]], Any]]
+    JSONType = Any
 
 _SERIALIZER = Serializer()
 # fmt: off
@@ -33,11 +34,11 @@ def build_generate_client_token_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     user_id = kwargs.pop('user_id', None)  # type: Optional[str]
     role = kwargs.pop('role', None)  # type: Optional[List[str]]
     minutes_to_expire = kwargs.pop('minutes_to_expire', 60)  # type: Optional[int]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/:generateToken')
@@ -75,10 +76,10 @@ def build_close_all_connections_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
     reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/:closeConnections')
@@ -114,10 +115,10 @@ def build_send_to_all_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     content_type = kwargs.pop('content_type', None)  # type: Optional[str]
     excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/:send')
@@ -154,7 +155,8 @@ def build_connection_exists_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/connections/{connectionId}')
@@ -188,9 +190,9 @@ def build_close_connection_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/connections/{connectionId}')
@@ -226,9 +228,9 @@ def build_send_to_connection_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     content_type = kwargs.pop('content_type', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/connections/{connectionId}/:send')
@@ -264,7 +266,8 @@ def build_group_exists_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/groups/{group}')
@@ -298,10 +301,10 @@ def build_close_group_connections_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
     reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/groups/{group}/:closeConnections')
@@ -339,10 +342,10 @@ def build_send_to_group_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     content_type = kwargs.pop('content_type', None)  # type: Optional[str]
     excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/groups/{group}/:send')
@@ -381,7 +384,8 @@ def build_add_connection_to_group_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/groups/{group}/connections/{connectionId}')
@@ -417,7 +421,8 @@ def build_remove_connection_from_group_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/groups/{group}/connections/{connectionId}')
@@ -452,7 +457,8 @@ def build_user_exists_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/users/{userId}')
@@ -486,10 +492,10 @@ def build_close_user_connections_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
     reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/users/{userId}/:closeConnections')
@@ -527,9 +533,9 @@ def build_send_to_user_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     content_type = kwargs.pop('content_type', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/users/{userId}/:send')
@@ -566,7 +572,8 @@ def build_add_user_to_group_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/users/{userId}/groups/{group}')
@@ -602,7 +609,8 @@ def build_remove_user_from_group_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/users/{userId}/groups/{group}')
@@ -637,7 +645,8 @@ def build_remove_user_from_all_groups_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
-    api_version = "2021-10-01"
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/users/{userId}/groups')
@@ -672,9 +681,9 @@ def build_grant_permission_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     target_name = kwargs.pop('target_name', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/permissions/{permission}/connections/{connectionId}')
@@ -712,9 +721,9 @@ def build_revoke_permission_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     target_name = kwargs.pop('target_name', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/permissions/{permission}/connections/{connectionId}')
@@ -752,9 +761,9 @@ def build_check_permission_request(
     **kwargs  # type: Any
 ):
     # type: (...) -> HttpRequest
+    api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
     target_name = kwargs.pop('target_name', None)  # type: Optional[str]
 
-    api_version = "2021-10-01"
     accept = "application/json, text/json"
     # Construct URL
     url = kwargs.pop("template_url", '/api/hubs/{hub}/permissions/{permission}/connections/{connectionId}')
@@ -807,6 +816,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :paramtype role: list[str]
         :keyword minutes_to_expire: The expire time of the generated token.
         :paramtype minutes_to_expire: int
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: JSON object
         :rtype: Any
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -825,13 +837,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         user_id = kwargs.pop('user_id', None)  # type: Optional[str]
         role = kwargs.pop('role', None)  # type: Optional[List[str]]
         minutes_to_expire = kwargs.pop('minutes_to_expire', 60)  # type: Optional[int]
 
-        
+
         request = build_generate_client_token_request(
             hub=hub,
+            api_version=api_version,
             user_id=user_id,
             role=role,
             minutes_to_expire=minutes_to_expire,
@@ -880,6 +894,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :paramtype excluded: list[str]
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -890,12 +907,14 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
         reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-        
+
         request = build_close_all_connections_request(
             hub=hub,
+            api_version=api_version,
             excluded=excluded,
             reason=reason,
             template_url=self.close_all_connections.metadata['url'],
@@ -937,6 +956,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type message: IO or str
         :keyword excluded: Excluded connection Ids.
         :paramtype excluded: list[str]
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -950,15 +972,16 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
         excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -967,6 +990,7 @@ class WebPubSubServiceClientOperationsMixin(object):
 
         request = build_send_to_all_request(
             hub=hub,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -1008,6 +1032,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type hub: str
         :param connection_id: The connection Id.
         :type connection_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1018,10 +1045,13 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_connection_exists_request(
             hub=hub,
             connection_id=connection_id,
+            api_version=api_version,
             template_url=self.connection_exists.metadata['url'],
         )
         path_format_arguments = {
@@ -1062,6 +1092,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type connection_id: str
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1072,12 +1105,14 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-        
+
         request = build_close_connection_request(
             hub=hub,
             connection_id=connection_id,
+            api_version=api_version,
             reason=reason,
             template_url=self.close_connection.metadata['url'],
         )
@@ -1104,7 +1139,7 @@ class WebPubSubServiceClientOperationsMixin(object):
         self,
         hub,  # type: str
         connection_id,  # type: str
-        message,  # type: Union[IO, str]
+        message,  # type: Union[IO, str, JSONType]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1118,7 +1153,10 @@ class WebPubSubServiceClientOperationsMixin(object):
         :param connection_id: The connection Id.
         :type connection_id: str
         :param message: The payload body.
-        :type message: IO or str
+        :type message: IO or str or JSONType
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -1132,14 +1170,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -1149,6 +1188,7 @@ class WebPubSubServiceClientOperationsMixin(object):
         request = build_send_to_connection_request(
             hub=hub,
             connection_id=connection_id,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -1189,6 +1229,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type hub: str
         :param group: Target group name, which length should be greater than 0 and less than 1025.
         :type group: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1199,10 +1242,13 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_group_exists_request(
             hub=hub,
             group=group,
+            api_version=api_version,
             template_url=self.group_exists.metadata['url'],
         )
         path_format_arguments = {
@@ -1245,6 +1291,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :paramtype excluded: list[str]
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1255,13 +1304,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
         reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-        
+
         request = build_close_group_connections_request(
             hub=hub,
             group=group,
+            api_version=api_version,
             excluded=excluded,
             reason=reason,
             template_url=self.close_group_connections.metadata['url'],
@@ -1289,7 +1340,7 @@ class WebPubSubServiceClientOperationsMixin(object):
         self,
         hub,  # type: str
         group,  # type: str
-        message,  # type: Union[IO, str]
+        message,  # type: Union[IO, str, JSONType]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1303,9 +1354,12 @@ class WebPubSubServiceClientOperationsMixin(object):
         :param group: Target group name, which length should be greater than 0 and less than 1025.
         :type group: str
         :param message: The payload body.
-        :type message: IO or str
+        :type message: IO or str or JSONType
         :keyword excluded: Excluded connection Ids.
         :paramtype excluded: list[str]
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -1319,15 +1373,16 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
         excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -1337,6 +1392,7 @@ class WebPubSubServiceClientOperationsMixin(object):
         request = build_send_to_group_request(
             hub=hub,
             group=group,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -1381,6 +1437,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type group: str
         :param connection_id: Target connection Id.
         :type connection_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1391,11 +1450,14 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_add_connection_to_group_request(
             hub=hub,
             group=group,
             connection_id=connection_id,
+            api_version=api_version,
             template_url=self.add_connection_to_group.metadata['url'],
         )
         path_format_arguments = {
@@ -1436,6 +1498,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type group: str
         :param connection_id: Target connection Id.
         :type connection_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1446,11 +1511,14 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_remove_connection_from_group_request(
             hub=hub,
             group=group,
             connection_id=connection_id,
+            api_version=api_version,
             template_url=self.remove_connection_from_group.metadata['url'],
         )
         path_format_arguments = {
@@ -1488,6 +1556,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type hub: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1498,10 +1569,13 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_user_exists_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.user_exists.metadata['url'],
         )
         path_format_arguments = {
@@ -1544,6 +1618,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :paramtype excluded: list[str]
         :keyword reason: The reason closing the client connection.
         :paramtype reason: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1554,13 +1631,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         excluded = kwargs.pop('excluded', None)  # type: Optional[List[str]]
         reason = kwargs.pop('reason', None)  # type: Optional[str]
 
-        
+
         request = build_close_user_connections_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             excluded=excluded,
             reason=reason,
             template_url=self.close_user_connections.metadata['url'],
@@ -1588,7 +1667,7 @@ class WebPubSubServiceClientOperationsMixin(object):
         self,
         hub,  # type: str
         user_id,  # type: str
-        message,  # type: Union[IO, str]
+        message,  # type: Union[IO, str, JSONType]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -1602,7 +1681,10 @@ class WebPubSubServiceClientOperationsMixin(object):
         :param user_id: The user Id.
         :type user_id: str
         :param message: The payload body.
-        :type message: IO or str
+        :type message: IO or str or JSONType
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :keyword str content_type: Media type of the body sent to the API. Default value is
          "application/json". Allowed values are: "application/json", "application/octet-stream",
          "text/plain."
@@ -1616,14 +1698,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        content_type = kwargs.pop('content_type', "text/plain")  # type: Optional[str]
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+        content_type = kwargs.pop('content_type', "application/json")  # type: Optional[str]
 
         json = None
         content = None
-        if content_type.split(";")[0] in ['application/json', 'application/octet-stream']:
-            content = message
-        elif content_type.split(";")[0] in ['text/plain']:
+        if content_type.split(";")[0] in ['application/json']:
             json = message
+        elif content_type.split(";")[0] in ['application/octet-stream', 'text/plain']:
+            content = message
         else:
             raise ValueError(
                 "The content_type '{}' is not one of the allowed values: "
@@ -1633,6 +1716,7 @@ class WebPubSubServiceClientOperationsMixin(object):
         request = build_send_to_user_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             content_type=content_type,
             json=json,
             content=content,
@@ -1676,6 +1760,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type group: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1686,11 +1773,14 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_add_user_to_group_request(
             hub=hub,
             group=group,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.add_user_to_group.metadata['url'],
         )
         path_format_arguments = {
@@ -1731,6 +1821,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type group: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1741,11 +1834,14 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_remove_user_from_group_request(
             hub=hub,
             group=group,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.remove_user_from_group.metadata['url'],
         )
         path_format_arguments = {
@@ -1783,6 +1879,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :type hub: str
         :param user_id: Target user Id.
         :type user_id: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1793,10 +1892,13 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
-        
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
+
+
         request = build_remove_user_from_all_groups_request(
             hub=hub,
             user_id=user_id,
+            api_version=api_version,
             template_url=self.remove_user_from_all_groups.metadata['url'],
         )
         path_format_arguments = {
@@ -1841,6 +1943,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :keyword target_name: The meaning of the target depends on the specific permission. For
          joinLeaveGroup and sendToGroup, targetName is a required parameter standing for the group name.
         :paramtype target_name: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1851,13 +1956,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         target_name = kwargs.pop('target_name', None)  # type: Optional[str]
 
-        
+
         request = build_grant_permission_request(
             hub=hub,
             permission=permission,
             connection_id=connection_id,
+            api_version=api_version,
             target_name=target_name,
             template_url=self.grant_permission.metadata['url'],
         )
@@ -1903,6 +2010,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :keyword target_name: The meaning of the target depends on the specific permission. For
          joinLeaveGroup and sendToGroup, targetName is a required parameter standing for the group name.
         :paramtype target_name: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: None
         :rtype: None
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1913,13 +2023,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         target_name = kwargs.pop('target_name', None)  # type: Optional[str]
 
-        
+
         request = build_revoke_permission_request(
             hub=hub,
             permission=permission,
             connection_id=connection_id,
+            api_version=api_version,
             target_name=target_name,
             template_url=self.revoke_permission.metadata['url'],
         )
@@ -1965,6 +2077,9 @@ class WebPubSubServiceClientOperationsMixin(object):
         :keyword target_name: The meaning of the target depends on the specific permission. For
          joinLeaveGroup and sendToGroup, targetName is a required parameter standing for the group name.
         :paramtype target_name: str
+        :keyword api_version: Api Version. The default value is "2021-10-01". Note that overriding this
+         default value may result in unsupported behavior.
+        :paramtype api_version: str
         :return: bool
         :rtype: bool
         :raises: ~azure.core.exceptions.HttpResponseError
@@ -1975,13 +2090,15 @@ class WebPubSubServiceClientOperationsMixin(object):
         }
         error_map.update(kwargs.pop('error_map', {}))
 
+        api_version = kwargs.pop('api_version', "2021-10-01")  # type: str
         target_name = kwargs.pop('target_name', None)  # type: Optional[str]
 
-        
+
         request = build_check_permission_request(
             hub=hub,
             permission=permission,
             connection_id=connection_id,
+            api_version=api_version,
             target_name=target_name,
             template_url=self.check_permission.metadata['url'],
         )

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/setup.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/setup.py
@@ -61,7 +61,7 @@ setup(
         ]
     ),
     install_requires=[
-        "azure-core<2.0.0,>=1.19.0",
+        "azure-core<2.0.0,>=1.19.1",
         "msrest>=0.6.21",
         "cryptography>=2.8.0",
         "pyjwt>=1.7.1",

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -220,7 +220,7 @@ opentelemetry-sdk<2.0.0,>=1.5.0,!=1.10a0
 #override azure-core-tracing-opentelemetry opentelemetry-api<2.0.0,>=1.0.0
 #override azure-identity six>=1.12.0
 #override azure-keyvault-keys six>=1.12.0
-#override azure-messaging-webpubsubservice azure-core<2.0.0,>=1.19.0
+#override azure-messaging-webpubsubservice azure-core<2.0.0,>=1.19.1
 #override azure-messaging-webpubsubservice msrest>=0.6.21
 #override azure-messaging-webpubsubservice pyjwt>=1.7.1
 #override azure-messaging-webpubsubservice six>=1.12.0


### PR DESCRIPTION
Regenerated with unreleased autorest (we're waiting for azure-core release to do this autorest release) to unblock webpubsub from autorest bug.

The changes here are:
1. constants are now overridable by kwargs. This is unrelated to the webpubsub bug, but it's a new feature we've added in autorest since last webpubsub generation
2. fix `text` being passed with the `json` kwarg to `azure.core.rest.HttpRequest`. This was the big issue that we were trying to fix
3. fixed the default content type to be `application/json` instead of `text/plain`.
4. fixed docstrings for json input


@msyyc I also recommend these following tests be added (sync and async) to the test suite. I'd add them before you merge this PR to make sure that you are able to repro the error of `text` being passed to `json`, and that merging this fix will cause the tests to pass. Sorry I can't add them myself, I don't have the webpubsub permission info to run them

```python
@WebpubsubPowerShellPreparer()
def test_webpubsub_send_to_all_operation_json(self, webpubsub_endpoint):
    client = self.create_client(endpoint=webpubsub_endpoint)
    client.send_to_all('Hub', {'hello': 'test_webpubsub_send_to_all'})

@WebpubsubPowerShellPreparer()
def test_webpubsub_send_to_all_operation_text(self, webpubsub_endpoint):
    client = self.create_client(endpoint=webpubsub_endpoint)
    client.send_to_all('Hub', 'test_webpubsub_send_request', content_type='text/plain')
```